### PR TITLE
borderBottomWidth property added

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,6 @@ var styles = StyleSheet.create({
     alignItems: 'flex-end',
     paddingBottom: 5,
     borderBottomColor: 'rgba(0, 0, 0, 0.5)',
-    borderBottomWidth: 1 / PixelRatio.get(),
     justifyContent: 'space-between',
   },
   customTitle: {
@@ -218,12 +217,18 @@ var NavigationBar = React.createClass({
     }
         
     var backgroundStyle = this.props.backgroundColor ?
-      { backgroundColor: this.props.backgroundColor } : {},
-        customStyle = this.props.style;
+      { backgroundColor: this.props.backgroundColor } : {};
+        
+    /*
+     * Custom navbar border styling
+     */
+    var borderBottomStyle = this.props.borderBottomWidth ?
+      { borderBottomWidth: this.props.borderBottomWidth } : {borderBottomWidth: 1 / PixelRatio.get()},
+      customStyle = this.props.style;
 
     return (
       <StaticContainer shouldUpdate={false}>
-        <View style={[styles.navBarContainer, backgroundStyle, customStyle ]}>
+        <View style={[styles.navBarContainer, backgroundStyle, customStyle, borderBottomStyle]}>
           {this.getTitleElement()}
           {this.getLeftButtonElement()}
           {this.getRightButtonElement()}

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ var styles = StyleSheet.create({
     alignItems: 'flex-end',
     paddingBottom: 5,
     borderBottomColor: 'rgba(0, 0, 0, 0.5)',
+    borderBottomWidth: 1 / PixelRatio.get(),
     justifyContent: 'space-between',
   },
   customTitle: {
@@ -223,7 +224,7 @@ var NavigationBar = React.createClass({
      * Custom navbar border styling
      */
     var borderBottomStyle = this.props.borderBottomWidth ?
-      { borderBottomWidth: this.props.borderBottomWidth } : {borderBottomWidth: 1 / PixelRatio.get()},
+      { borderBottomWidth: this.props.borderBottomWidth } : {},
       customStyle = this.props.style;
 
     return (


### PR DESCRIPTION
This is kind of a workaround for hiding navbar border, because I still can't pass borderBottomWidth: 0 in with success.. but I CAN do: 
```var navBar = 
<NavigationBar
      backgroundColor={route.index == 3 ? colors.white : colors.lightGrey}
      borderBottomWidth={route.index == 3 ? .0001 : null}
      customPrev={route.index == 0 ? <CustomPrev/> : null}
      customTitle={route.index == 3 ? null : <CustomTitle/>}
      onPrev={ () => {this.handlePrev(route, navigator)} }
    />;```
to completely hide my navbar when on a specific view (index 3 in my case).


@JonasJonny @Kureev 