### PR TITLE
Add statusBar property

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,6 +30,10 @@ const StatusBarShape = {
 };
 
 function customizeStatusBar(data) {
+  if (!data.customizable) {
+    return;
+  }
+
   if (data.style) {
     StatusBarIOS.setStyle(data.style, true);
   }
@@ -118,6 +122,7 @@ export default class NavigationBar extends Component {
 
   static defaultProps = {
     statusBar: {
+      customizable: true,
       style: 'default',
       hidden: false,
       hideAnimation: 'slide',


### PR DESCRIPTION
When `ViewControllerBasedStatusBarAppearance` key in the Info.plist is set to YES, any attempt to `setStyle` or `setHidden` on `StatusBarIOS` will cause an exception be thrown. It may be reasonable to add a `customizable` key on  the configuration of `statusBar` to leave the right to users.